### PR TITLE
Correct syntax of architectures value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ maintainer=Jose Rullan <jerullan@yahoo.com>
 sentence="A simple state machine implementation."
 url=http://github.com/jrullan/StateMachine
 paragraph=A state machine is implemented by defining state logic as a function in your sketch. Transitions are implemented as functions returning a boolean value and a next state number. Requires LinkedList library https://github.com/ivanseidel/LinkedList.
-architectures="*"
+architectures=*
 includes=StateMachine.h


### PR DESCRIPTION
Putting the library.properties `architectures` value in quotes causes it to be interpreted as a specific architecture named `"*"` instead of a wildcard match. This causes the following warning whenever the library is used:
```
WARNING: library StateMachine claims to run on ("*") architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```