### PR TITLE
get rid of compiler warning (remove typedef)

### DIFF
--- a/src/State.h
+++ b/src/State.h
@@ -8,7 +8,7 @@
  * a function that evaluates whether or not not transition
  * from the current state and the number of the state to transition to
  */
-typedef struct Transition{
+struct Transition{
   bool (*conditionFunction)();
   int stateNumber;
 };


### PR DESCRIPTION
The `typedef` keyword is unwanted in this context (we are not naming a new type), so compiler generates a warning. Removing typedef makes compiler happy.

P.S. Thank you so much for this library, @jrullan! I was going to write something similar for a project and your code saved me quite a few hours of work!