### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,3 +8,4 @@ url=http://github.com/jrullan/StateMachine
 paragraph=A state machine is implemented by defining state logic as a function in your sketch. Transitions are implemented as functions returning a boolean value and a next state number. Requires LinkedList library https://github.com/ivanseidel/LinkedList.
 architectures=*
 includes=StateMachine.h
+depends=LinkedList


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format