### PR TITLE
Fix problem with transitionTo() inside state's logic

### DIFF
--- a/src/StateMachine.h
+++ b/src/StateMachine.h
@@ -50,10 +50,15 @@ void StateMachine::run(){
   }
   
   // Execute state logic and return transitioned
-  // to state number. 
+  // to state number. Remember the current state then check
+  // if it wasnt't changed in state logic. If it was, we 
+  // should ignore predefined transitions.
+  int initialState = currentState;
   int next = stateList->get(currentState)->execute();
-  executeOnce = (currentState == next)?false:true;
-  currentState = next;
+  if(initialState == currentState){
+    executeOnce = (currentState == next)?false:true;
+    currentState = next;
+  }
 }
 
 /*


### PR DESCRIPTION
We should ignore predefined transition rules after state executing if current state was changed inside state's logic