### PR TITLE
Added a method to check if the machine is currently in a given state

### DIFF
--- a/src/StateMachine.cpp
+++ b/src/StateMachine.cpp
@@ -69,3 +69,7 @@ int StateMachine::transitionTo(int i){
   }
   return currentState;
 }
+
+bool StateMachine::isInState(State* s){
+  return this->stateList->get(this->currentState) == s;
+}

--- a/src/StateMachine.h
+++ b/src/StateMachine.h
@@ -19,6 +19,7 @@ class StateMachine
     State* addState(void (*functionPointer)());
     State* transitionTo(State* s);
     int transitionTo(int i);
+    bool isInState(State* s);
 	
     // Attributes
     LinkedList<State*> *stateList;


### PR DESCRIPTION
The isInState() method takes a State pointer to check if it is the current state of the machine. This is useful when you want to execute some come outside the state functions (in an ISR, for example) depending on the current state.